### PR TITLE
Inclusive guard checking

### DIFF
--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/api/SlicedInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/api/SlicedInjectionPointSelector.java
@@ -65,33 +65,6 @@ public class SlicedInjectionPointSelector {
     }
 
     /**
-     * Obtains the instruction immediately after the next instruction.
-     *
-     * <p>Handle with care, improper use may lead to unexpected behaviour with frames or jumps!
-     * The method is mainly intended to be used in order to easily check whether an instruction lies between
-     * two other instructions.
-     *
-     * @param method The method to find the entrypoints in.
-     * @param remapper The remapper instance to make use of. This is used to remap any references of the mixin class to the target class when applying injection point constraints.
-     * @param sharedBuilder Shared {@link StringBuilder} instance to reduce {@link StringBuilder} allocations.
-     * @return Instruction immediately after the next instruction.
-     */
-    @Nullable
-    public AbstractInsnNode getAfterSelected(@NotNull MethodNode method, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
-        AbstractInsnNode first = this.getFirstInsn(method, remapper, sharedBuilder);
-        if (first == null) {
-            return null;
-        }
-        AbstractInsnNode selected = ASMUtil.afterInstruction(first);
-        AbstractInsnNode afterSelected = selected.getNext();
-        if (afterSelected == null) {
-            return selected;
-        } else {
-            return afterSelected;
-        }
-    }
-
-    /**
      * Obtains the first {@link AbstractInsnNode} that corresponds to the first applicable entrypoint within
      * the provided method as defined by this {@link InjectionPointSelector}. The {@link AbstractInsnNode} may
      * not be virtual, that is it may not have an {@link AbstractInsnNode#getOpcode() opcode} value of -1.

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/ConstantInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/ConstantInjectionPointSelector.java
@@ -62,11 +62,14 @@ public class ConstantInjectionPointSelector extends InjectionPointSelector {
     @Nullable
     public AbstractInsnNode getFirstInsn(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (this.constSelector.matchesConstant(insn)) {
                 return insn;
+            }
+            if(insn == guard) {
+                break;
             }
         }
 
@@ -84,11 +87,14 @@ public class ConstantInjectionPointSelector extends InjectionPointSelector {
     public Collection<? extends AbstractInsnNode> getMatchedInstructions(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (this.constSelector.matchesConstant(insn)) {
                 matched.add(insn);
+            }
+            if(insn == guard) {
+                break;
             }
         }
 

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/FieldInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/FieldInjectionPointSelector.java
@@ -62,11 +62,14 @@ public class FieldInjectionPointSelector extends InjectionPointSelector {
     @Nullable
     public AbstractInsnNode getFirstInsn(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (insn instanceof FieldInsnNode && this.constraint.isValid(insn, remapper, sharedBuilder)) {
                 return insn;
+            }
+            if(insn == guard) {
+                break;
             }
         }
 
@@ -84,11 +87,14 @@ public class FieldInjectionPointSelector extends InjectionPointSelector {
     public Collection<? extends AbstractInsnNode> getMatchedInstructions(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (insn instanceof FieldInsnNode && this.constraint.isValid(insn, remapper, sharedBuilder)) {
                 matched.add(insn);
+            }
+            if(insn == guard) {
+                break;
             }
         }
 

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/InvokeInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/InvokeInjectionPointSelector.java
@@ -62,11 +62,14 @@ public class InvokeInjectionPointSelector extends InjectionPointSelector {
     @Nullable
     public AbstractInsnNode getFirstInsn(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (insn instanceof MethodInsnNode && this.constraint.isValid(insn, remapper, sharedBuilder)) {
                 return insn;
+            }
+            if(insn == guard) {
+                break;
             }
         }
 
@@ -84,11 +87,14 @@ public class InvokeInjectionPointSelector extends InjectionPointSelector {
     public Collection<? extends AbstractInsnNode> getMatchedInstructions(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (insn instanceof MethodInsnNode && this.constraint.isValid(insn, remapper, sharedBuilder)) {
                 matched.add(insn);
+            }
+            if(insn == guard) {
+                break;
             }
         }
 

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/LoadInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/LoadInjectionPointSelector.java
@@ -33,11 +33,14 @@ public class LoadInjectionPointSelector extends InjectionPointSelector implement
             @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper,
             @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isLoad(insn.getOpcode())) {
                 return insn;
+            }
+            if(insn == guard) {
+                break;
             }
         }
 
@@ -57,11 +60,14 @@ public class LoadInjectionPointSelector extends InjectionPointSelector implement
             @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isLoad(insn.getOpcode())) {
                 matched.add(insn);
+            }
+            if(insn == guard) {
+                break;
             }
         }
 

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/ReturnInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/ReturnInjectionPointSelector.java
@@ -30,7 +30,7 @@ public class ReturnInjectionPointSelector extends InjectionPointSelector impleme
     @Nullable
     public AbstractInsnNode getFirstInsn(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
         for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isReturn(insn.getOpcode())) {
@@ -55,7 +55,7 @@ public class ReturnInjectionPointSelector extends InjectionPointSelector impleme
     public Collection<? extends AbstractInsnNode> getMatchedInstructions(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
         for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isReturn(insn.getOpcode())) {

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/StoreInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/StoreInjectionPointSelector.java
@@ -33,11 +33,14 @@ public class StoreInjectionPointSelector extends InjectionPointSelector implemen
             @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper,
             @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isStore(insn.getOpcode())) {
                 return insn.getNext();
+            }
+            if(insn == guard) {
+                break;
             }
         }
 
@@ -57,11 +60,14 @@ public class StoreInjectionPointSelector extends InjectionPointSelector implemen
             @NotNull StringBuilder sharedBuilder) {
         List<AbstractInsnNode> matched = new ArrayList<AbstractInsnNode>();
         AbstractInsnNode insn = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode guard = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getNext()) {
+        for (; insn != null; insn = insn.getNext()) {
             if (ASMUtil.isStore(insn.getOpcode())) {
                 matched.add(ASMUtil.getNext(insn));
+            }
+            if(insn == guard) {
+                break;
             }
         }
 

--- a/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/TailInjectionPointSelector.java
+++ b/micromixin-transformer/src/main/java/org/stianloader/micromixin/transform/internal/selectors/inject/TailInjectionPointSelector.java
@@ -30,11 +30,14 @@ public class TailInjectionPointSelector extends InjectionPointSelector implement
     @Nullable
     public AbstractInsnNode getFirstInsn(@NotNull MethodNode method, @Nullable SlicedInjectionPointSelector from, @Nullable SlicedInjectionPointSelector to, @NotNull SimpleRemapper remapper, @NotNull StringBuilder sharedBuilder) {
         AbstractInsnNode guard = from == null ? method.instructions.getFirst() : from.getFirstInsn(method, remapper, sharedBuilder);
-        AbstractInsnNode insn = to == null ? method.instructions.getLast() : to.getAfterSelected(method, remapper, sharedBuilder);
+        AbstractInsnNode insn = to == null ? method.instructions.getLast() : to.getFirstInsn(method, remapper, sharedBuilder);
 
-        for (; insn != null && insn != guard; insn = insn.getPrevious()) {
+        for (; insn != null; insn = insn.getPrevious()) {
             if (ASMUtil.isReturn(insn.getOpcode())) {
                 return insn;
+            }
+            if(insn == guard) {
+                break;
             }
         }
 


### PR DESCRIPTION
This set of changes is a followup to #4 and modifies the behavior of `@At` matching, that way the loop ends on the guard instruction, including guard. Previous behavior specified guard as the instruction after matched which required extra processing (like skipping frames or labels) as seen in SlicedInjectionPointSelector.getAfterSelected.

It was still flawed regardless, as when the matching instruction is the last instruction in MethodNode.instructions, it will end up on null, which means it will throw an IllegalStateException about exhausted instruction list